### PR TITLE
Docker容器运行优化

### DIFF
--- a/.github/workflows/go-manual.yml
+++ b/.github/workflows/go-manual.yml
@@ -14,8 +14,8 @@ on:
           - nightly
 
 env:
-  REGISTRY_SERVER_ADDRESS: ghcr.io/miracleeverywhere/dst-management-platform-api
-
+  # REGISTRY_SERVER_ADDRESS: ghcr.io/miracleeverywhere/dst-management-platform-api
+  REGISTRY_SERVER_ADDRESS: ghcr.io/${{ github.repository }}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,9 @@ services:
 
   dmp:
     # image: ghcr.io/harelive/dst-management-platform-api:latest # 测试用
-    image: ghcr.io/miracleeverywhere/dst-management-platform-api:latest
+    # image: ghcr.io/miracleeverywhere/dst-management-platform-api:latest #原地址
+    image: ghcr.nju.edu.cn/miracleeverywhere/dst-management-platform-api:latest #加速地址
+    
     container_name: dmp
 
     ports:
@@ -25,17 +27,20 @@ services:
       - 8769:8769/udp
       - 8769:8769/tcp
 
-    # 新建一个文件夹存Dockerfile
+    # 新建一个文件夹存docker-compose.yml,映射文件与docker-compose.yml同一级
     volumes:
       - ./.klei:/root/.klei
       - ./config:/root/config
       - ./dst:/root/dst
       - ./steamcmd:/root/steamcmd
+      # 同步宿主机时间(linux内核)
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     network_mode: bridge
 
-    # restart: unless-stopped #选择是否开机自启
+    # restart: unless-stopped #开机自启
     environment:
-      - TZ=Asia/Shanghai
+      # - TZ=Asia/Shanghai #宿主机非Linux内核使用
       - PGID=$(id -g)
       - PUID=$(id -u)
       - DMP_PORT=80

--- a/docker/entry-point.sh
+++ b/docker/entry-point.sh
@@ -34,16 +34,19 @@ fi
 cleanup() {
     echo "Received SIGTERM, cleaning up..."
     # 发送停止信号给 dmp 进程
-    pkill -f dmp
-    echo "Stopped dmp process"
+    if [[ -n "$DMP_PID" ]]; then
+        kill "$DMP_PID"
+        echo "Stopped dmp process with PID $DMP_PID"
+    fi
     exit 0
 }
 
 # 捕获 SIGTERM 信号
 trap cleanup SIGTERM
 
-# 启动 dmp
-exec ./dmp -l "$DMP_PORT" -c -s ./config > "$DMP_HOME/dmp.log" 2>&1
+# 启动 dmp 并获取其 PID
+./dmp -l "$DMP_PORT" -c -s ./config > "$DMP_HOME/dmp.log" 2>&1 &
+DMP_PID=$!  # 获取 dmp 进程的 PID
 
 # 让脚本保持运行状态，直到收到信号
 while true; do

--- a/docker/entry-point.sh
+++ b/docker/entry-point.sh
@@ -5,30 +5,47 @@ DMP_HOME="/root"
 DMP_DB="./config/DstMP.sdb"
 
 # 安装必要的依赖
-apt update
-apt install -y wget unzip jq screen
+apt-get update
+apt-get install -y wget unzip jq screen
 
 cd $DMP_HOME || exit
 
 # 检查是否为64位启动
 if [ -e "$DMP_DB" ]; then
-	bit64=$(jq -r .bit64 "$DMP_DB")
+    bit64=$(jq -r .bit64 "$DMP_DB")
 else
-	bit64="false"
+    bit64="false"
 fi
 
-#安装对应的DST依赖
+# 安装对应的DST依赖
 if [[ "$bit64" == "true" ]]; then
-    apt install -y lib32gcc1
-    apt install -y lib32gcc-s1
-    apt install -y libcurl4-gnutls-dev
+    apt-get install -y lib32gcc1
+    apt-get install -y lib32gcc-s1
+    apt-get install -y libcurl4-gnutls-dev
 else
     dpkg --add-architecture i386
-    apt update
-    apt install -y lib32gcc1
-    apt install -y lib32gcc-s1
-    apt install -y libcurl4-gnutls-dev:i386
+    apt-get update
+    apt-get install -y lib32gcc1
+    apt-get install -y lib32gcc-s1
+    apt-get install -y libcurl4-gnutls-dev:i386
 fi
 
-#启动dmp
-exec ./dmp -l "$DMP_PORT" -c -s ./config > $DMP_HOME/dmp.log 2>&1
+# 定义 SIGTERM 信号处理函数
+cleanup() {
+    echo "Received SIGTERM, cleaning up..."
+    # 发送停止信号给 dmp 进程
+    pkill -f dmp
+    echo "Stopped dmp process"
+    exit 0
+}
+
+# 捕获 SIGTERM 信号
+trap cleanup SIGTERM
+
+# 启动 dmp
+exec ./dmp -l "$DMP_PORT" -c -s ./config > "$DMP_HOME/dmp.log" 2>&1
+
+# 让脚本保持运行状态，直到收到信号
+while true; do
+    sleep 1
+done


### PR DESCRIPTION
1. 修复docker容器退出时返回错误码(2)，原因为未对退出SIGTERM信号进行处理。
2. entry-point.sh启动文件中改为使用apt-get，避免在无交互执行命令时报warning。
3. 修改docker-compose文件，添加同步宿主机时间(linux内核)。