### PR TITLE
Fix/multiple issues

### DIFF
--- a/app/setting/handlers.go
+++ b/app/setting/handlers.go
@@ -1932,12 +1932,12 @@ func handleAddClientModsDisabledConfig(c *gin.Context) {
 		return
 	}
 
-	modFileLines := strings.Split(cluster.Mod, "\n")
-	var newModFileLines []string
-	newModFileLines = append(newModFileLines, modFileLines[0])
-	newModFileLines = append(newModFileLines, "  client_mods_disabled={configuration_options={}, enabled=true},")
-	newModFileLines = append(newModFileLines, modFileLines[1:]...)
-	cluster.Mod = strings.Join(newModFileLines, "\n")
+	//预防配置中 return { ... } 大括号不换行的情况
+	re := regexp.MustCompile(`return\s*{`)
+	text := re.ReplaceAllString(cluster.Mod, "return {\n")
+	modFileLines := strings.Split(text, "\n")
+	modFileLines[0] += "\n  client_mods_disabled={configuration_options={}, enabled=true},\n"
+	cluster.Mod = strings.Join(modFileLines, "\n")
 
 	err = SaveSetting(cluster)
 	if err != nil {

--- a/app/setting/settingUtils.go
+++ b/app/setting/settingUtils.go
@@ -550,9 +550,14 @@ func ClearFiles() {
 
 func getList(filepath string) []string {
 	// 预留位 黑名单 管理员
+	err := utils.EnsureFileExists(filepath)
+	if err != nil {
+		utils.Logger.Error("创建文件失败", "err", err, "file", filepath)
+		return []string{}
+	}
 	al, err := utils.ReadLinesToSlice(filepath)
 	if err != nil {
-		utils.Logger.Warn("读取文件失败", "err", err, "file", filepath)
+		utils.Logger.Error("读取文件失败", "err", err, "file", filepath)
 		return []string{}
 	}
 	var uidList []string


### PR DESCRIPTION
修复：
1.在 adminlist.txt 等文件不存在时平台日志会持续性的报 warning。修改为在文件不存在时自动创建。
2.`client_mods_disabled` 接口会在模组列表文件中大括号不换行时导致错误，将 `client_mods_disabled={configuration_options={}, enabled=true},` 添加到括号外。如
```lua
return {}
  client_mods_disabled={configuration_options={}, enabled=true},
```