### PR TITLE
config(docker): 添加日志级别配置选项

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       - PGID=$(id -g)
       - PUID=$(id -u)
       - DMP_PORT=80
+#      - 日志打印级别
+      - LEVEL=info
     # 修改 dns 降低steam连接失败概率
 #    dns:
 #        - 144.144.144.144

--- a/docker/entry-point.sh
+++ b/docker/entry-point.sh
@@ -20,7 +20,7 @@ cleanup() {
 trap cleanup SIGTERM
 
 # 启动 dmp 并获取其 PID
-./dmp -bind "$DMP_PORT" -dbpath ./data -level info 2>&1 &
+./dmp -bind "$DMP_PORT" -dbpath ./data -level" ${LEVEL:-info}" 2>&1 &
 DMP_PID=$!  # 获取 dmp 进程的 PID
 
 # 让脚本保持运行状态，直到收到信号


### PR DESCRIPTION
- 在 docker-compose.yml 中添加 LEVEL 环境变量，默认值为 info
- 修改 entry-point.sh 中的 dmp 启动命令，使用环境变量 LEVEL 控制日志级别
- 当 LEVEL 环境变量未设置时，默认使用 info 级别