### PR TITLE
ln强制覆盖软链接

### DIFF
--- a/embedFS/shell/manual_install.sh
+++ b/embedFS/shell/manual_install.sh
@@ -33,7 +33,7 @@ function install_rhel() {
     yum -y install glibc.i686 libstdc++.i686 libcurl.i686
     yum -y install glibc libstdc++ libcurl
     yum -y install screen wget
-    ln -s /usr/lib/libcurl.so.4 /usr/lib/libcurl-gnutls.so.4
+    ln -sf /usr/lib/libcurl.so.4 /usr/lib/libcurl-gnutls.so.4
 }
 
 function check_screen() {
@@ -93,11 +93,11 @@ rm -rf "$DST_DIR/steamapps/appmanifest_343050.acf"
 cd "$WORK_DIR" || error_exit
 cp steamcmd/linux32/libstdc++.so.6 dst/bin/lib32/
 if [[ "${OS}" == "ubuntu" || "${OS}" == "debian" ]]; then
-	[ ! -L "dst/bin64/lib64/libcurl-gnutls.so.4" ] && ln -s /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4 dst/bin64/lib64/libcurl-gnutls.so.4
-	[ ! -L "dst/bin/lib32/libcurl-gnutls.so.4" ] && ln -s /usr/lib/i386-linux-gnu/libcurl-gnutls.so.4 dst/bin/lib32/libcurl-gnutls.so.4
+	[ ! -L "dst/bin64/lib64/libcurl-gnutls.so.4" ] && ln -sf /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4 dst/bin64/lib64/libcurl-gnutls.so.4
+	[ ! -L "dst/bin/lib32/libcurl-gnutls.so.4" ] && ln -sf /usr/lib/i386-linux-gnu/libcurl-gnutls.so.4 dst/bin/lib32/libcurl-gnutls.so.4
 else
-	[ ! -L "dst/bin64/lib64/libcurl-gnutls.so.4" ] && ln -s /usr/lib64/libcurl.so.4 dst/bin64/lib64/libcurl-gnutls.so.4
-	[ ! -L "dst/bin/lib32/libcurl-gnutls.so.4" ] && ln -s /usr/lib/libcurl.so.4 dst/bin/lib32/libcurl-gnutls.so.4
+	[ ! -L "dst/bin64/lib64/libcurl-gnutls.so.4" ] && ln -sf /usr/lib64/libcurl.so.4 dst/bin64/lib64/libcurl-gnutls.so.4
+	[ ! -L "dst/bin/lib32/libcurl-gnutls.so.4" ] && ln -sf /usr/lib/libcurl.so.4 dst/bin/lib32/libcurl-gnutls.so.4
 fi
 
 # luajit


### PR DESCRIPTION
我在云服务器(CentOS 9 Stream)上由于手动部署过饥荒dedicated_server，因此手动创建了libcurl-gnutls.so.4软链接，因此安装dmp时执行到ln -s由于运行失败会直接退出脚本，这里建议直接强制覆盖libcurl-gnutls.so.4.