### PR TITLE
增加HTTP返回压缩

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.4
 require (
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/gin-contrib/gzip v1.2.6
 	github.com/gin-contrib/pprof v1.5.3
 	github.com/gin-gonic/gin v1.11.0
 	github.com/glebarez/sqlite v1.11.0

--- a/server/flags.go
+++ b/server/flags.go
@@ -5,17 +5,19 @@ import (
 )
 
 var (
-	bindPort    int
-	dbPath      string
-	logLevel    string
-	versionShow bool
-	consoleCmd  string
-	cert        string
-	key         string
+	bindPort          int
+	dbPath            string
+	logLevel          string
+	versionShow       bool
+	consoleCmd        string
+	cert              string
+	key               string
+	noHttpCompression bool
 )
 
 func bindFlags() {
 	flag.IntVar(&bindPort, "bind", 80, "DMP端口, 如: -bind 8080")
+	flag.BoolVar(&noHttpCompression, "no-http-compress", false, "http响应gzip压缩文本数据，默认启动，关闭使用：-no-http-compress")
 	flag.StringVar(&dbPath, "dbpath", "data", "数据库文件目录, 如: -dbpath ./data")
 	flag.StringVar(&logLevel, "level", "info", "日志等级, 如: -level debug")
 	flag.StringVar(&cert, "cert", "", "证书文件路径, 不填则启动http, 例如: /path/to/fullchain.pem")

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/gin-contrib/gzip"
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
 	static "github.com/soulteary/gin-static"
@@ -86,6 +87,20 @@ func Run() {
 	}))
 	// 静态资源缓存
 	r.Use(middleware.CacheControl())
+
+	// 启用Gzip压缩文本类型, 默认级别level6, 1kb开始压缩
+	// 不能使用 gzip.WithCustomShouldCompressFn，因为c.JSON()拿不到Content-Type类型，这样需要手写write方法。
+	// 先个蠢办法把，后续使用同一返回再优化这里。
+	if !noHttpCompression {
+		r.Use(gzip.Gzip(
+			gzip.DefaultCompression,
+			gzip.WithMinLength(1024),
+			gzip.WithExcludedExtensions([]string{
+				".woff", ".woff2", ".ttf",
+				".png", ".jpeg", "jpg", ".gif", ".webp", ".ico",
+				".zip", ".gz", ".tar", ".rar", ".7z",
+			})))
+	}
 
 	// debug日志等级下，注册pprof路由
 	if logLevel == "debug" {


### PR DESCRIPTION
在没有前置HTTP服务器如Nginx的情况下，默认Http返回启用Gizp压缩。
在版本3.1.6的情况下

| 比对数据| 原始 | Gzip压缩 |
|--|--|--|
|没有缓存大小|4.7M|2.5M|
|5M带宽理论时间|7.5秒|4秒|

为啥没有质的飞跃，因为还有个1.6M的字体。