### PR TITLE
存档下载使用A标签。token从header移至query

### DIFF
--- a/app/tools/handler.go
+++ b/app/tools/handler.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -216,6 +217,7 @@ func (h *Handler) backupDownloadGet(c *gin.Context) {
 	type ReqForm struct {
 		RoomID   int    `json:"roomID" form:"roomID"`
 		Filename string `json:"filename" form:"filename"`
+		Token    string `json:"token" form:"token"`
 	}
 	var reqForm ReqForm
 	if err := c.ShouldBindQuery(&reqForm); err != nil {
@@ -223,7 +225,16 @@ func (h *Handler) backupDownloadGet(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"code": 400, "message": message.Get(c, "bad request"), "data": nil})
 		return
 	}
-
+	// 1. 验证token
+	tokenSecret := db.JwtSecret
+	claims, err := utils.ValidateJWT(reqForm.Token, []byte(tokenSecret))
+	if err != nil {
+		logger.Logger.Errorf("token认证失败: %v", err)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "认证失败"})
+		return
+	}
+	c.Set("username", claims.Username)
+	c.Set("role", claims.Role)
 	// 2. 参数验证
 	if reqForm.RoomID == 0 || reqForm.Filename == "" {
 		c.JSON(http.StatusOK, gin.H{"code": 400, "message": message.Get(c, "bad request"), "data": nil})
@@ -240,7 +251,7 @@ func (h *Handler) backupDownloadGet(c *gin.Context) {
 	}
 	// 4. 构建文件路径
 	filePath := fmt.Sprintf("dmp_files/backup/%d/%s", reqForm.RoomID, reqForm.Filename)
-
+	c.Header("Content-Disposition", "attachment; filename="+url.QueryEscape(reqForm.Filename))
 	c.File(filePath)
 }
 

--- a/app/tools/router.go
+++ b/app/tools/router.go
@@ -11,13 +11,15 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	v := r.Group(utils.ApiVersion)
 	{
 		tools := v.Group("tools")
+		// 使用浏览器A标签Get，无法带header认证 ，token验证放到handle里面执行
+		// 暂时需要.zip后缀，否则会进行Gzip压缩
+		tools.GET("/backup/download.zip", h.backupDownloadGet)
 		tools.Use(middleware.TokenCheck())
 		{
 			tools.GET("/backup", h.backupGet)
 			tools.POST("/backup", h.backupPost)
 			tools.DELETE("/backup", h.backupDelete)
 			tools.POST("/backup/restore", h.backupRestorePost)
-			tools.GET("/backup/download", h.backupDownloadGet)
 			tools.GET("/announce", h.announceGet)
 			tools.PUT("/announce", h.announcePut)
 			tools.GET("/map", h.mapGet)


### PR DESCRIPTION
解决Axios打大文件下载时候的迷惑行为，先把所有的数据放入内存，再从内存变为文件。
当带宽小，存档大的时候，没有进度条，实在使人焦虑。
改为存档使用A标签进行下载。


### 改进地方
1. 配合前端解决迷惑行文，鉴权从Header改为Query。
2. 增加一个.zip后缀，防止Gzip对文zip压缩。
3. 服务端写入下载的文件名

前后端请一起合并

同时我看到别的地方也用了Query传入Token。是不是考虑下鉴权中间件调整，也可以从cookie鉴权，这样浏览器会自动携带进来。网页使用Cookie，API使用Header。