### PR TITLE
存档下载更新

### DIFF
--- a/app/tools/handler.go
+++ b/app/tools/handler.go
@@ -14,8 +14,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -240,8 +242,38 @@ func (h *Handler) backupDownloadGet(c *gin.Context) {
 	}
 	// 4. 构建文件路径
 	filePath := fmt.Sprintf("dmp_files/backup/%d/%s", reqForm.RoomID, reqForm.Filename)
-
-	c.File(filePath)
+	// 5. 构造文件名
+	fileName := reqForm.Filename
+	base64Str := strings.TrimSuffix(fileName, ".zip")
+	decodeFilename, err := utils.Base64Decode(base64Str)
+	if err != nil {
+		c.FileAttachment(filePath, fileName)
+		return
+	}
+	// 房间名，房间天数，备份时间
+	decodeFilenameParts := strings.Split(decodeFilename, "<-@dmp@->")
+	roomName := decodeFilenameParts[0]
+	cycle := decodeFilenameParts[1] + "天"
+	if len(decodeFilenameParts) != 3 {
+		c.FileAttachment(filePath, fileName)
+		return
+	}
+	// 文件名安全替换
+	var invalidChars = regexp.MustCompile(`[\x00-\x1f\\/:*?"<>|]`)
+	roomName = invalidChars.ReplaceAllString(decodeFilenameParts[0], "")
+	if roomName == "" {
+		roomName = "存档"
+	}
+	ms, err := strconv.ParseInt(decodeFilenameParts[2], 10, 64)
+	if err != nil {
+		fileName = fmt.Sprintf("%s_%s.zip", roomName, cycle)
+		c.FileAttachment(filePath, fileName)
+		return
+	}
+	ts := time.UnixMilli(ms)
+	tsStr := ts.Format("2006-01-02-15-04")
+	fileName = fmt.Sprintf("%s_%s_%s.zip", roomName, cycle, tsStr)
+	c.FileAttachment(filePath, fileName)
 }
 
 func (h *Handler) announceGet(c *gin.Context) {

--- a/app/tools/handler.go
+++ b/app/tools/handler.go
@@ -252,13 +252,13 @@ func (h *Handler) backupDownloadGet(c *gin.Context) {
 	}
 	// 房间名，房间天数，备份时间
 	decodeFilenameParts := strings.Split(decodeFilename, "<-@dmp@->")
-	roomName := decodeFilenameParts[0]
-	cycle := decodeFilenameParts[1] + "天"
 	if len(decodeFilenameParts) != 3 {
 		c.FileAttachment(filePath, fileName)
 		return
 	}
 	// 文件名安全替换
+	roomName := decodeFilenameParts[0]
+	cycle := decodeFilenameParts[1] + "天"
 	var invalidChars = regexp.MustCompile(`[\x00-\x1f\\/:*?"<>|]`)
 	roomName = invalidChars.ReplaceAllString(decodeFilenameParts[0], "")
 	if roomName == "" {

--- a/app/user/handler.go
+++ b/app/user/handler.go
@@ -170,7 +170,7 @@ func (h *Handler) loginPost(c *gin.Context) {
 
 	// 登录成功后缓存 token 版本号
 	db.SetTokenVersion(dbUser.Username, dbUser.TokenVersion)
-
+	c.SetCookie("X-DMP-TOKEN", token, 3600*utils.JwtExpirationHours, `/`+utils.ApiVersion+`/tools/backup/download`, "", false, true)
 	c.JSON(http.StatusOK, gin.H{"code": 200, "message": message.Get(c, "login success"), "data": token})
 }
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -17,6 +17,9 @@ import (
 func TokenCheck() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := c.Request.Header.Get("X-DMP-TOKEN")
+		if token == "" {
+			token, _ = c.Cookie("X-DMP-TOKEN")
+		}
 		claims, err := utils.ValidateJWT(token, []byte(db.JwtSecret))
 		if err != nil {
 			logger.Logger.Warnf("未授权的访问, DMP已拦截, ip为: %s", c.ClientIP())
@@ -51,6 +54,7 @@ func TokenCheck() gin.HandlerFunc {
 				logger.Logger.Errorf("刷新Token失败：%v", err)
 			} else {
 				c.Header("X-DMP-NEW-TOKEN", token)
+				c.SetCookie("X-DMP-TOKEN", token, 3600*utils.JwtExpirationHours, `/`+utils.ApiVersion+`/tools/backup/download`, "", false, true)
 			}
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -95,6 +95,9 @@ func Run() {
 		r.Use(gzip.Gzip(
 			gzip.DefaultCompression,
 			gzip.WithMinLength(1024),
+			gzip.WithExcludedPaths([]string{
+				"/" + utils.ApiVersion + "/tools/backup/download",
+			}),
 			gzip.WithExcludedExtensions([]string{
 				".woff", ".woff2", ".ttf",
 				".png", ".jpeg", "jpg", ".gif", ".webp", ".ico",


### PR DESCRIPTION
1. 存档URL增加Cookie鉴权，方便有Cookie的情况下使用Get直链。
2. 优化存档下载的文件名，存档更直观。
3. 存档URL不使用Zip压缩。

注意：Token没有刷新的话，下载存档会出现未授权，退出重新登录就行了。