### PR TITLE
修复导入存档世界/模组配置含 Klei 头或 BOM 导致前端解析失败的问题

### DIFF
--- a/app/room/handler.go
+++ b/app/room/handler.go
@@ -402,6 +402,13 @@ func (h *Handler) roomGet(c *gin.Context) {
 	}
 	data.WorldData = *worlds
 
+	// 归一化世界/模组配置，剥离 BOM、Klei 引擎头等非法前缀，避免前端世界配置页解析失败；
+	// 同时可自愈历史导入的脏数据：前端拿到干净内容并保存后会写回数据库与磁盘。
+	for i := range data.WorldData {
+		data.WorldData[i].LevelData = utils.NormalizeLuaConfig(data.WorldData[i].LevelData)
+		data.WorldData[i].ModData = utils.NormalizeLuaConfig(data.WorldData[i].ModData)
+	}
+
 	roomSetting, err := h.roomSettingDao.GetRoomSettingsByRoomID(reqForm.RoomID)
 	if err != nil {
 		logger.Logger.Errorf("查询数据库失败, err: %v", err)

--- a/app/room/utils.go
+++ b/app/room/utils.go
@@ -525,13 +525,17 @@ func handleUpload(savePath, unzipPath string, room *models.Room, worlds *[]model
 				return "level data not found", fmt.Errorf("未发现世界配置")
 			}
 		}
-		world.LevelData = levelData
+		// 归一化世界配置，剥离 BOM / Klei 引擎头等非法前缀，避免前端世界配置页解析失败
+		world.LevelData = utils.NormalizeLuaConfig(levelData)
+		if world.LevelData != levelData {
+			logger.Logger.Infof("世界配置含非法前缀(BOM/Klei头)，已自动归一化，世界目录: %s", i)
+		}
 
 		// 读取mod配置 modoverrides.lua
 		modDataPath := fmt.Sprintf("%s/%s/modoverrides.lua", clusterDir, i)
 		modData, err := utils.GetFileAllContent(modDataPath)
 		if err == nil {
-			world.ModData = modData
+			world.ModData = utils.NormalizeLuaConfig(modData)
 		}
 
 		uploadExtraInfo.worldPath = append(uploadExtraInfo.worldPath, worldPath)

--- a/utils/safeLua.go
+++ b/utils/safeLua.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/yuin/gopher-lua"
 )
@@ -38,4 +40,21 @@ func NewSafeLuaState() *lua.LState {
 		L.SetGlobal(name, lua.LNil)
 	}
 	return L
+}
+
+// kleiSaveHeaderPattern 匹配 Klei 引擎写入存档时添加的头部（形如 "KLEI     1 "）。
+// 该头部不是合法 Lua，会导致前端严格的 Lua 5.1 解析器报错。
+var kleiSaveHeaderPattern = regexp.MustCompile(`^KLEI\s+\d+\s*`)
+
+// NormalizeLuaConfig 归一化 DST 的 lua 配置文件内容（leveldataoverride.lua、modoverrides.lua 等），
+// 仅剥离会导致前端解析失败的非法前缀，不改动其余合法内容：
+//  1. UTF-8 BOM（\ufeff）；
+//  2. Klei 引擎存档头（形如 "KLEI     1 "），其后才是真正的 "return { ... }"。
+//
+// 前端保存房间时会用严格的 Lua 5.1 解析器校验每个世界的配置，上述前缀会触发
+// “世界代码配置格式错误”/“模组配置格式错误”，导致整个房间表单无法保存。
+func NormalizeLuaConfig(content string) string {
+	content = strings.TrimPrefix(content, "\ufeff")
+	content = kleiSaveHeaderPattern.ReplaceAllString(content, "")
+	return content
 }


### PR DESCRIPTION
## 问题现象

导入存档（`.zip`）后，进入房间「世界配置」页面点击保存时，前端报错 **「世界代码配置格式错误」/「模组配置格式错误」**，导致整个房间表单无法保存。

## 根因

Klei 引擎写入存档时，会在 `leveldataoverride.lua`、`modoverrides.lua` 等文件开头加上一个存档头（形如 `KLEI     1 `，约 11 字节），部分文件还可能带 UTF-8 BOM（`\ufeff`）。

这些前缀**不是合法 Lua 语法**。前端保存房间时会用严格的 Lua 5.1 解析器校验每个世界的配置，遇到该前缀即解析失败。而 DMP 导入时把文件内容原样存下、未做归一化，脏数据便被一路带到前端。

## 修复方案

新增 `utils.NormalizeLuaConfig`，**仅剥离会导致前端解析失败的非法前缀，不改动其余任何合法内容**：

1. UTF-8 BOM（`\ufeff`）；
2. Klei 引擎存档头（正则 `^KLEI\s+\d+\s*`），其后才是真正的 `return { ... }`。

并在两处接入：

- **导入时**（`app/room/utils.go` → `handleUpload`）：写入数据库前归一化 `LevelData` / `ModData`，检测到非法前缀时记录日志。
- **读取时**（`app/room/handler.go` → `roomGet`）：返回前端前归一化，可**自愈历史导入的脏数据**——前端拿到干净内容、保存后会写回数据库与磁盘。

## 影响范围

| 文件 | 改动 |
| --- | --- |
| `utils/safeLua.go` | 新增 `NormalizeLuaConfig`（+19） |
| `app/room/utils.go` | 导入时归一化 + 日志（+8 / -2） |
| `app/room/handler.go` | 读取时归一化（+7） |

纯前缀剥离，不改合法配置内容，向后兼容；对不含非法前缀的存档为无操作（no-op）。

## 验证

- **gofmt**：改动的 3 个文件在 LF 下均通过。
- **go vet ./utils/... ./app/room/...**：通过（exit 0）。
- **实机部署验证**：在真实服务器部署本分支后导入含 Klei 头的存档，服务端日志出现「世界配置含非法前缀(BOM/Klei头)，已自动归一化，世界目录: Caves」，前端世界配置页不再报「格式错误」，可正常保存。
