### PR TITLE
修复统一模组配置下固定读第一个分世界导致获取模组配置失败的问题

### DIFF
--- a/dst/mod.go
+++ b/dst/mod.go
@@ -379,7 +379,10 @@ func (g *Game) getDownloadedMods() *[]DownloadedMod {
 	}
 
 	// 获取ugc
-	gameAcfPath := fmt.Sprintf("%s/%s/appworkshop_322330.acf", g.ugcPath, g.worldSaveData[0].WorldName)
+	// 统一模组配置下各分世界共享同一套模组，但导入存档或游戏服务端自行下载可能只
+	// 填充了部分分世界目录，这里回退到实际存在模组目录的分世界，避免固定读第一个分
+	// 世界(Master)时因目录缺失导致 EnsureFileExists 失败、获取已下载模组失败。
+	gameAcfPath := fmt.Sprintf("%s/%s/appworkshop_322330.acf", g.ugcPath, g.resolveUgcWorld("content/322330"))
 	err = utils.EnsureFileExists(gameAcfPath)
 	if err != nil {
 		logger.Logger.Errorf("EnsureFileExists失败, path: %v", gameAcfPath)
@@ -408,11 +411,34 @@ func (g *Game) getDownloadedMods() *[]DownloadedMod {
 	return &downloadedMods
 }
 
+// resolveUgcWorld 按 worldSaveData 顺序返回 ugc 目录下第一个存在相对路径 rel 的分世界名。
+//
+// 统一模组配置(ModInOne)下各分世界共享同一套模组，但导入存档或游戏服务端自行下载
+// 模组时可能只填充了部分分世界目录（例如只有 Caves 而没有 Master）。若固定读第一个
+// 分世界，会因目录/文件缺失导致“获取模组配置失败”。这里返回第一个实际存在 rel 的分
+// 世界（因此第一个分世界存在时仍优先使用它）；若都不存在则回退到第一个分世界名，保持
+// 原有报错语义。rel 可为目录(如 "content/322330")或具体文件(如
+// "content/322330/<id>/modinfo.lua")。
+func (g *Game) resolveUgcWorld(rel string) string {
+	if len(g.worldSaveData) == 0 {
+		return ""
+	}
+	for _, world := range g.worldSaveData {
+		if utils.FileDirectoryExists(fmt.Sprintf("%s/%s/%s", g.ugcPath, world.WorldName, rel)) {
+			return world.WorldName
+		}
+	}
+	return g.worldSaveData[0].WorldName
+}
+
 func (g *Game) getModConfigureOptions(worldID, modID int, ugc bool) (*[]ConfigurationOption, error) {
 	var modinfoLuaPath string
 	if g.room.ModInOne {
 		if ugc {
-			modinfoLuaPath = fmt.Sprintf("%s/%s/content/322330/%d/modinfo.lua", g.ugcPath, g.worldSaveData[0].WorldName, modID)
+			// 统一模组配置下各分世界共享同一套模组，但导入存档或游戏服务端自行下载可能
+			// 只填充了部分分世界目录，这里回退到实际含有该模组的分世界，避免固定读第一个
+			// 分世界(Master)时因 modinfo.lua 缺失导致获取模组配置失败。
+			modinfoLuaPath = fmt.Sprintf("%s/%s/content/322330/%d/modinfo.lua", g.ugcPath, g.resolveUgcWorld(fmt.Sprintf("content/322330/%d/modinfo.lua", modID)), modID)
 		} else {
 			modinfoLuaPath = fmt.Sprintf("%s/workshop-%d/modinfo.lua", g.notUgcPath, modID)
 		}


### PR DESCRIPTION
继 #145 之后的另一处导入相关健壮性修复。

## 问题

统一模组配置（ModInOne）下各分世界共享同一套模组，但读取模组信息的两处代码**固定使用第一个分世界**（`worldSaveData[0]`，通常是 `Master`）：

- `getDownloadedMods`：读取 `{ugcPath}/{world}/appworkshop_322330.acf`
- `getModConfigureOptions`（ModInOne + ugc 分支）：读取 `{ugcPath}/{world}/content/322330/{modID}/modinfo.lua`

当模组文件实际只存在于其它分世界时（例如**导入的存档**，或**游戏服务端自行**把创意工坊模组只下载到了 `Caves` 而 `Master` 缺失），固定读第一个分世界会因目录/文件缺失而失败：

```
EnsureFileExists失败, path: .../Master/appworkshop_322330.acf
读取modinfo文件失败, err: open .../Master/content/322330/<id>/modinfo.lua: no such file or directory
获取模组设置失败
```

## 修复

新增 `resolveUgcWorld(rel string) string`：按 `worldSaveData` 顺序返回 ugc 目录下**第一个实际存在相对路径 `rel`** 的分世界名。

- 第一个分世界存在目标时**仍优先使用它**（行为不变）；
- 缺失时回退到真正含有该 acf / 模组的分世界；
- 都不存在时回退到第一个分世界名，**保持原有报错语义**；
- `worldSaveData` 为空时返回空串，避免 `worldSaveData[0]` 越界 panic。

两处读取分别用 `resolveUgcWorld("content/322330")` 与**按模组**的 `resolveUgcWorld("content/322330/{modID}/modinfo.lua")` 解析；后者粒度到单个模组，即使模组分散在不同分世界也能各归各位。

## 影响范围

- 仅改动**读取**路径；写入/下载路径（`downloadMod` / `processAcf`）本就会 `mkdir -p` 并拷贝到**所有**分世界，无需改动。
- 非 ModInOne（各分世界独立模组）分支按 `worldID` 精确匹配分世界，本就正确，未改动。
- 向后兼容：正常场景（所有分世界都有模组）行为完全不变。

## 验证

- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...` 通过；
- `gofmt` 干净，`go vet ./dst/...` 无新增告警。
